### PR TITLE
Fix Forward history button tool tip from "Go Back" to "Go Forward"

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -1,7 +1,7 @@
 <div id="breadcrumbs-bar">
     <div id="history-buttons">
         <button onclick="window.history.back()" class="tree-floating-button bx bx-left-arrow-circle tree-settings-button" title="Go Back"></button>
-        <button onclick="window.history.forward()" class="tree-floating-button bx bx-right-arrow-circle tree-settings-button" title="Go Back"></button>
+        <button onclick="window.history.forward()" class="tree-floating-button bx bx-right-arrow-circle tree-settings-button" title="Go Forward"></button>
     </div>
     <div id="breadcrumbs"></div>
 </div>


### PR DESCRIPTION
Just changing the title tag to reflect what the forward history button is doing. 